### PR TITLE
Feature/GitHub actions path filters

### DIFF
--- a/.github/workflows/build-vscode-linux.yml
+++ b/.github/workflows/build-vscode-linux.yml
@@ -5,9 +5,12 @@
 
 name: Create and publish a Docker image
 
-on: [push]#, pull_request]
-  #push:
-    #branches: ['r']
+on:
+  push:
+    paths:
+      - 'containers/vscode-linux/**'
+      - '.pre-commit-config.yaml'
+      - '.github/workflows/build-vscode-linux.yml'
 
 env:
   REGISTRY: ghcr.io
@@ -40,8 +43,6 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
-          #driver-opts: image=moby/buildkit:0.9.1
-          #context: containers/vscode-linux
           file: containers/vscode-linux/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Create and publish a Docker image](https://github.com/xmlabs-io/exemaitch/actions/workflows/build-vscode-linux.yml/badge.svg)](https://github.com/xmlabs-io/exemaitch/actions/workflows/build-vscode-linux.yml)
 
 ## Code Quailty
+
 ### Pre-commit
 
 This project uses [pre-commit](https://pre-commit.com/) to automatically run `mypy`, `black` and `flake8` before commits.

--- a/README.md
+++ b/README.md
@@ -43,5 +43,3 @@ To run `black`, fixing issues:
 ```shell script
 $ black .
 ```
-
-


### PR DESCRIPTION
# Description 
This pullrequest adds path filtering to the Github build action for the development container.  
Any Code push that does not contain changed files with any of the set path parameters will not trigger a new vscode development build. 

The paths that will trigger new devcontainer build are 
      - 'containers/vscode-linux/**'
      - '.pre-commit-config.yaml'
      - '.github/workflows/build-vscode-linux.yml'
      
 # To test 
- Change /add any file outside of the above given paths (example the README.md file).  After commit and push there should NOT be a github action job triggered for the development container

- Change/ add any file in the above gvien paths (Example containers/vscode-linux/Dockerfile ) After commit and push there should be a new github actions build job running generating a new VSCODE docker container